### PR TITLE
Removing duplicate loader for font files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,13 +114,6 @@ module.exports = {
           "less-loader"
         ]
       },
-      { 
-        "exclude": [
-          /\/node_modules\//
-        ],
-        test: /\.(woff2?|ttf|eot|svg)$/, 
-        loaders: ['url-loader?limit=10000&name=[name].[ext]']
-      },
       {
         "exclude": [
           path.join(process.cwd(), "client\\styles.css"),


### PR DESCRIPTION
This duplicate loader was making fiont files corrupt.
This loader was added unintentionally while adding global css.