### PR TITLE
Adding tooltipModule.

### DIFF
--- a/client/app/home/home.module.ts
+++ b/client/app/home/home.module.ts
@@ -5,6 +5,8 @@ import { FormsModule }  from '@angular/forms';
 
 import { ROUTES }       from './home.routes';
 
+import { TooltipModule } from 'ng2-bootstrap';
+
 import { Layout } from './layout.component';
 import { Sidebar } from './sidebar/sidebar.component';
 import { Navbar } from './navbar/navbar.component';


### PR DESCRIPTION
Tooltip module removed while removing extra imports, but is required for the child component sidebar